### PR TITLE
Merge TÜBİTAK ULAKBİM's changes to master.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage
 config/database.yml
 config/secrets.yml
 config/branding.yml
+config/credentials.yml
 
 # Ignore some of the initializers
 config/initializers/wicked_pdf.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,6 +47,9 @@ module DMPRoadmap
 
     # Set the default host for mailer URLs
     config.action_mailer.default_url_options = { host: Socket.gethostname.to_s }
+    config.i18n.enforce_available_locales = false
+    I18n.config.enforce_available_locales = false
+    config.i18n.available_locales = [:"en-US"]
 
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,4 +96,4 @@ Rails.application.configure do
 end
 
 # Used by Rails' routes url_helpers (typically when including a link in an email)
-Rails.application.routes.default_url_options[:host] = "example.org"
+Rails.application.routes.default_url_options[:host] = "vyp.ulakbim.gov.tr"


### PR DESCRIPTION
This patch set makes the initial changes required for DMP Roadmap to run under http://vyp.ulakbim.gov.tr

Changes proposed in this PR:
- Fix `I18n::InvalidLocale` problem during installation.
- Change application route to `vyp.ulakbim.gov.tr` under production environment.
- Update `.gitignore` to ignore some more sensitive files.
